### PR TITLE
Fixed error when using matrix enabled buttons.

### DIFF
--- a/src/internal/Buttons.h
+++ b/src/internal/Buttons.h
@@ -114,6 +114,10 @@ namespace DcsBios {
 				}
 			}
 
+      void resetState() {
+        lastState_ = (lastState_==0)?-1:0;
+      }
+
 		public:
       //init now expects a message (the identifier you are trying to control), an argument ("TOGGLE") and an address to a storage variable
 			MatActionButtonT(const char* msg, const char* arg, volatile unsigned char* argAddress) :
@@ -147,6 +151,10 @@ namespace DcsBios {
 					lastState_ = state;
 				}
 			}
+
+      void resetState() {
+        lastState_ = (lastState_==0)?-1:0;
+      }
 
 		public:
       //init now expects a message (the identifier you are trying to control), an argument ("TOGGLE") and an address to a storage variable
@@ -186,6 +194,10 @@ namespace DcsBios {
 				}
 			}
 
+      void resetState() {
+        lastState_ = (lastState_==0)?-1:0;
+      }
+
 		public:
       //init now expects row and column, as well as an array pointer, instead of a pin
 			MatActionButtonSetT(const char* msg, volatile unsigned char* argAddress, char onLvlArg) :
@@ -197,7 +209,7 @@ namespace DcsBios {
 				lastState_ = *address;
 			}  
 	};
-	typedef MatActionButtonToggleT<> MatActionButtonToggle;
+	typedef MatActionButtonSetT<> MatActionButtonSet;
 }
 
 #endif


### PR DESCRIPTION
Added function resetState() for classes  MatActionButtonToggleT, MatActionButtonT and MatActionButtonSetT.
Corrected typedef for MatActionButtonSet.