### PR TITLE
Add GitHub App access token policy for automated Addresses.h updates

### DIFF
--- a/.github/access-token.yaml
+++ b/.github/access-token.yaml
@@ -1,0 +1,8 @@
+origin: DCS-Skunkworks/dcs-bios-arduino-library
+
+statements:
+  - subjects:
+      - repo:DCS-Skunkworks/dcs-bios:**
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Adds `.github/access-token.yaml` to authorize the `dcs-bios` release workflow to request a temporary GitHub App token via `qoomon/actions--access-token`. This allows the `update-arduino-addresses.yml` workflow in `DCS-Skunkworks/dcs-bios` to open pull requests against this repo without a long-lived PAT.

This is the final setup step described in DCS-Skunkworks/dcs-bios#1618.